### PR TITLE
Bugfix: wrong query generated on interface column

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
 
     <artifactId>datanucleus-rdbms</artifactId>
-    <version>5.2.8</version>
+    <version>5.2.8-prive-patched</version>
 
     <name>DataNucleus RDBMS plugin</name>
     <description>


### PR DESCRIPTION
Given
```
interface I{...}
interface I2{...}
class Other implements I {...}
class Base implements I {...}
class Mid extends Base implementds I2 {...}
class Impl extends Mid {...}

class Target{
 I col;
 I2 col2;
}
```

When
a)
  filter = "this.col = val"
  parameter = "Impl val"
  execute JDO query with a Impl(key=123) as the parameter
b)
  filter = "this.col = val"
  parameter = "Base val"
  execute JDO query with a Base(key=456) as the parameter

Then
Expected SQL
`SELECT ... FROM TARGET WHERE TARGET.COL_BASE_EID = 123`
`SELECT ... FROM TARGET WHERE TARGET.COL_BASE_EID = 456`

Actual SQL
for query a)
`SELECT ... FROM TARGET WHERE TARGET.COL_BASE_EID = 123`
for query b)
`SELECT ... FROM TARGET WHERE TARGET.COL_OTHER_EID = 456 AND TARGET.COL_OTHER_EID = null`

This patch should correct the the above SQL when filter on `col`.

But the case of `col2` is not addressed yet.